### PR TITLE
Fix warning if data in wordcloud2 has more than one class

### DIFF
--- a/R/wordcloud2.R
+++ b/R/wordcloud2.R
@@ -94,7 +94,7 @@ wordcloud2 <- function(data,
                        figPath = NULL,
                        hoverFunction = NULL
                        ) {
-  if(class(data) =="table"){
+  if("table" %in% class(data)){
     dataOut = data.frame(name = names(data),
                          freq = as.vector(data))
   }else{

--- a/R/wordcloud2.R
+++ b/R/wordcloud2.R
@@ -13,7 +13,7 @@
 ##'
 ##' @param data   A data frame including word and freq in each column
 ##' @param size   Font size, default is 1. The larger size means the bigger word.
-##' @param minSize    A character string of the subtitle
+##' @param minSize  minimum font size to draw on the canvas.
 ##' @param gridSize  Size of the grid in pixels for marking the availability of the canvas
 ##' the larger the grid size, the bigger the gap between words.
 ##' @param fontFamily Font to use.


### PR DESCRIPTION
If you provide an object with more than one class then the first `if` condition in `wordcloud2` produces a warning. This is especially true with `tidyr` tibbles that are both tibbles and `data .frames`

> wordcounts %>% mutate(freq=n) %>% wordcloud2(minSize=6)
Warning message:
In if (class(data) == "table") { :
  the condition has length > 1 and only the first element will be used

The pull request changes the condition such that it looks for a table *somewhere* in the vector of classes.